### PR TITLE
Fix search pos on file with leading whitespace

### DIFF
--- a/app/src/main/kotlin/org/fossify/filemanager/activities/ReadTextActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/ReadTextActivity.kt
@@ -316,7 +316,7 @@ class ReadTextActivity : SimpleActivity() {
         binding.readTextView.text?.clearBackgroundSpans()
 
         if (text.isNotBlank() && text.length > 1) {
-            searchMatches = binding.readTextView.value.searchMatches(text)
+            searchMatches = binding.readTextView.text.toString().searchMatches(text)
             binding.readTextView.highlightText(text, getProperPrimaryColor())
         }
 


### PR DESCRIPTION
This fixes a bug when using the File Editor's search feature on a file that contains leading whitespace. The bug is that when pressing the "<" and ">" buttons to go to the prev/next match, the cursor position is wrong -- it is shifted left by the amount of whitespace at the start of the file. (Note that this this about the cursor position; the highlighting does not have this issue.)

From the commit message:

> The extension property `EditText.value` trims leading/trailing whitespace, so using it to calculate the locations of the search matches produces incorrect indices if the file has leading whitespace.
> 
> (This affects the cursor position when going to the next/prev match. It does not affect the highlighting of matches.)