### PR TITLE
Remove the unused string "compress_pro"

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -14,7 +14,6 @@
     <string name="show_recents">إظهار الأحدث</string>
     <string name="invert_colors">عكس الألوان</string>
     <string name="compress">ضغط</string>
-    <string name="compress_pro">ضغط (Pro)</string>
     <string name="decompress">فك الضغط</string>
     <string name="compress_as">ضغط كا</string>
     <string name="compressing">ضغط…</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -11,7 +11,6 @@
     <string name="search_folder">Qovluq axtar</string>
     <string name="rooted_device_only">Bu əməliyyat yalnız root\'lu cihazlarda işləyir</string>
     <string name="compress">Sıxışdır</string>
-    <string name="compress_pro">Sıxışdır (Pro)</string>
     <string name="decompress">Çıxar</string>
     <string name="compress_as">Sıxışdır</string>
     <string name="compressing">Sıxışdırılır…</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Відэа</string>
     <string name="other_file">Іншае</string>
     <string name="compress">Сціснуць</string>
-    <string name="compress_pro">Сціснуць (Pro)</string>
     <string name="decompress">Распакаваць</string>
     <string name="compress_as">Сціснуць як</string>
     <string name="compressing">Сцісканне…</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Видео файл</string>
     <string name="other_file">Друг тип файл</string>
     <string name="compress">Компресиране</string>
-    <string name="compress_pro">Компресиране (Pro)</string>
     <string name="decompress">Декомпресиране</string>
     <string name="compress_as">Компресиране като</string>
     <string name="compressing">Компресира се…</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -19,7 +19,6 @@
     <string name="video_file">Fitxer de vídeo</string>
     <string name="other_file">Altres fitxers</string>
     <string name="compress">Comprimeix</string>
-    <string name="compress_pro">Comprimeix (Pro)</string>
     <string name="decompress">Descomprimeix</string>
     <string name="compress_as">Comprimeix com a</string>
     <string name="compressing">S\'està comprimint…</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Video soubor</string>
     <string name="other_file">Jiný soubor</string>
     <string name="compress">Komprimovat</string>
-    <string name="compress_pro">Komprimovat (Pro)</string>
     <string name="decompress">Rozbalit</string>
     <string name="compress_as">Komprimovat jako</string>
     <string name="compressing">Komprimuje se…</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -17,7 +17,6 @@
     <string name="video_file">Ffeil fideo</string>
     <string name="other_file">Ffeil arall</string>
     <string name="compress">Cywasgu</string>
-    <string name="compress_pro">Cywasgu (Pro)</string>
     <string name="decompress">Datgywasgu</string>
     <string name="compress_as">Cywasgu fel</string>
     <string name="compressing">Yn cywasgu…</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -19,7 +19,6 @@
     <string name="video_file">Videofil</string>
     <string name="other_file">Anden fil</string>
     <string name="compress">Komprimer</string>
-    <string name="compress_pro">Komprimer (Pro)</string>
     <string name="decompress">Dekomprimer</string>
     <string name="compress_as">Komprimer som</string>
     <string name="compressing">Komprimerer…</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Videodatei</string>
     <string name="other_file">Anderer Dateityp</string>
     <string name="compress">Komprimieren</string>
-    <string name="compress_pro">Komprimieren (Pro)</string>
     <string name="decompress">Entpacken</string>
     <string name="compress_as">Komprimieren als</string>
     <string name="compressing">Komprimieren …</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Αρχείο Βίντεο</string>
     <string name="other_file">Άλλος τύπος</string>
     <string name="compress">Συμπίεση</string>
-    <string name="compress_pro">Συμπίεση (Pro)</string>
     <string name="decompress">Αποσυμπίεση</string>
     <string name="compress_as">Συμπίεση ως</string>
     <string name="compressing">Συμπιέζεται…</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -8,7 +8,6 @@
     <string name="video_file">Filma dosiero</string>
     <string name="other_file">Alia dosiero</string>
     <string name="compress">Densigi</string>
-    <string name="compress_pro">Densigi (Pro)</string>
     <string name="decompress">Maldensigi</string>
     <string name="compress_as">Densigi kiel</string>
     <string name="compressing">Densigante…</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Video</string>
     <string name="other_file">Otro tipo de archivo</string>
     <string name="compress">Comprimir</string>
-    <string name="compress_pro">Comprimir (Pro)</string>
     <string name="decompress">Descomprimir</string>
     <string name="compress_as">Comprimir como</string>
     <string name="compressing">Comprimiendo…</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">videofailina</string>
     <string name="other_file">muu failina</string>
     <string name="compress">Paki kokku</string>
-    <string name="compress_pro">Paki kokku (Pro)</string>
     <string name="decompress">Paki lahti</string>
     <string name="compress_as">Paki kokku kui</string>
     <string name="compressing">Kokkupakkimine…</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -33,7 +33,6 @@
     <string name="decompressing">Deskonprimatzen…</string>
     <string name="decompression_successful">Deskonprimatzea behar bezala burutu da</string>
     <string name="compressing_failed">Trinkotzeak huts egin du</string>
-    <string name="compress_pro">Trinkotu (Pro)</string>
     <string name="decompress">Deskonprimatu</string>
     <string name="go_to_favorite">Joan gogokoetara</string>
     <string name="archives">Artxiboak</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Videotiedostona</string>
     <string name="other_file">Jonakin muuna tiedostona</string>
     <string name="compress">Pakkaa</string>
-    <string name="compress_pro">Pakkaa (Pro)</string>
     <string name="decompress">Pura</string>
     <string name="compress_as">Pakkausmuoto</string>
     <string name="compressing">Pakataan…</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Fichier vidéo</string>
     <string name="other_file">Autre fichier</string>
     <string name="compress">Compresser</string>
-    <string name="compress_pro">Compresser (Pro)</string>
     <string name="decompress">Décompresser</string>
     <string name="compress_as">Compresser sous</string>
     <string name="compressing">Compression…</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -19,7 +19,6 @@
     <string name="video_file">Vídeo</string>
     <string name="other_file">Outro tipo de ficheiro</string>
     <string name="compress">Comprimir</string>
-    <string name="compress_pro">Comprimir (Pro)</string>
     <string name="decompress">Descomprimir</string>
     <string name="compress_as">Comprimir como</string>
     <string name="compressing">Comprimindo…</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -19,7 +19,6 @@
     <string name="video_file">वीडियो फ़ाइलें</string>
     <string name="other_file">अन्य फ़ाइलें</string>
     <string name="compress">संपीड़न</string>
-    <string name="compress_pro">संपीड़न (Pro)</string>
     <string name="decompress">अवसाद</string>
     <string name="compress_as">इस रूप में संपीड़न</string>
     <string name="compressing">संपीड़न हो रहा है</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Video datoteka</string>
     <string name="other_file">Ostala datoteka</string>
     <string name="compress">Komprimiraj</string>
-    <string name="compress_pro">Komprimiraj (Pro)</string>
     <string name="decompress">Dekomprimiraj</string>
     <string name="compress_as">Komprimiraj kao</string>
     <string name="compressing">Komprimiranje…</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Videófájl</string>
     <string name="other_file">Egyéb fájl</string>
     <string name="compress">Tömörítés</string>
-    <string name="compress_pro">Tömörítés (Pro)</string>
     <string name="decompress">Kibontás</string>
     <string name="compress_as">Tömörítés másként</string>
     <string name="compressing">Tömörítés…</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -19,7 +19,6 @@
     <string name="video_file">Berkas video</string>
     <string name="other_file">Berkas lainnya</string>
     <string name="compress">Kompres</string>
-    <string name="compress_pro">Kompres (Pro)</string>
     <string name="decompress">Dekompres</string>
     <string name="compress_as">Kompres sebagai</string>
     <string name="compressing">Mengompres…</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Myndbandsskrá</string>
     <string name="other_file">Annað</string>
     <string name="compress">Þjappa</string>
-    <string name="compress_pro">Þjappa (Pro)</string>
     <string name="decompress">Afþjappa</string>
     <string name="compress_as">Þjappa sem</string>
     <string name="compressing">Að þjappa…</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">File video</string>
     <string name="other_file">Altro</string>
     <string name="compress">Comprimi</string>
-    <string name="compress_pro">Comprimi (Pro)</string>
     <string name="decompress">Decomprimi</string>
     <string name="compress_as">Comprimi come</string>
     <string name="compressing">Compressione…</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">קובץ וידיאו</string>
     <string name="other_file">קובץ אחר</string>
     <string name="compress">לדחוס</string>
-    <string name="compress_pro">דחיסה (פרו)</string>
     <string name="decompress">לבטל דחיסה</string>
     <string name="compress_as">דחוס כ</string>
     <string name="compressing">דוחס…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">動画ファイル</string>
     <string name="other_file">その他のファイル</string>
     <string name="compress">圧縮</string>
-    <string name="compress_pro">圧縮 (Pro)</string>
     <string name="decompress">解凍</string>
     <string name="compress_as">形式を指定して圧縮</string>
     <string name="compressing">圧縮しています…</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -10,7 +10,6 @@
     <string name="select_audio_file">오디도 파일을 선택하세요.</string>
     <string name="search_folder">폴더 및 파일검색</string>
     <string name="compress">압축</string>
-    <string name="compress_pro">압축 (Pro)</string>
     <string name="decompress">압축 해제</string>
     <string name="compress_as">압축 파일을 다음과 같이 생성함</string>
     <string name="compressing">압축중…</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -13,7 +13,6 @@
     <string name="video_file">Vaizdo įrašo failas</string>
     <string name="other_file">Kitas failas</string>
     <string name="compress">Glaudinti</string>
-    <string name="compress_pro">Glaudinti (Pro)</string>
     <string name="decompress">Išskleisti</string>
     <string name="compress_as">Glaudinti kaip</string>
     <string name="compressing">Glaudinama…</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">ဗီဒီယိုဖိုင်</string>
     <string name="other_file">အခြားဖိုင်</string>
     <string name="compress">ချုံ့မယ်</string>
-    <string name="compress_pro">ချုံ့မယ်(ပရို)</string>
     <string name="decompress">ဖြည်မယ်</string>
     <string name="compress_as">ဖိုင်ကိုဘယ်လိုချုံ့မလဲ</string>
     <string name="compressing">ဖိုင်ကိုချုံ့​နေသည်…</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -19,7 +19,6 @@
     <string name="video_file">Videofil</string>
     <string name="other_file">Annen fil</string>
     <string name="compress">Komprimer</string>
-    <string name="compress_pro">Komprimer (Pro)</string>
     <string name="decompress">Dekomprimer</string>
     <string name="compress_as">Komprimer som</string>
     <string name="compressing">Komprimerer…</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -19,7 +19,6 @@
     <string name="video_file">Video</string>
     <string name="other_file">Overig</string>
     <string name="compress">Inpakken</string>
-    <string name="compress_pro">Inpakken (Pro)</string>
     <string name="decompress">Uitpakken</string>
     <string name="compress_as">Inpakken als</string>
     <string name="compressing">Inpakken…</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">ویڈیو دی فائل</string>
     <string name="other_file">ہور فائل</string>
     <string name="compress">زیپ کرو</string>
-    <string name="compress_pro">کمپریس (فیز ورژن)</string>
     <string name="decompress">اݨزیپ کرو</string>
     <string name="compress_as">چوݨ نال زیپ کرو</string>
     <string name="compressing">زیپ کیتیاں جا رہیاں اے۔ ۔ ۔</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Plik wideo</string>
     <string name="other_file">Inny plik</string>
     <string name="compress">Spakuj</string>
-    <string name="compress_pro">Spakuj (Pro)</string>
     <string name="decompress">Rozpakuj</string>
     <string name="compress_as">Spakuj jako</string>
     <string name="compressing">Pakowanie…</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Arquivo de Vídeo</string>
     <string name="other_file">Outro arquivo</string>
     <string name="compress">Compactar</string>
-    <string name="compress_pro">Compactar (Pro)</string>
     <string name="decompress">Descompactar</string>
     <string name="compress_as">Compactar como</string>
     <string name="compressing">Compactando…</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Vídeo</string>
     <string name="other_file">Outro tipo</string>
     <string name="compress">Compactar</string>
-    <string name="compress_pro">Compactar (Pro)</string>
     <string name="decompress">Descompactar</string>
     <string name="compress_as">Compactar como</string>
     <string name="compressing">A compactar…</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Fişier video</string>
     <string name="other_file">Alt fișier</string>
     <string name="compress">Comprimare</string>
-    <string name="compress_pro">Comprimare (Pro)</string>
     <string name="decompress">Decomprimare</string>
     <string name="compress_as">Comprimaţi ca</string>
     <string name="compressing">Comprimare…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Видео</string>
     <string name="other_file">Другое</string>
     <string name="compress">Сжать</string>
-    <string name="compress_pro">Сжать (Pro)</string>
     <string name="decompress">Извлечь</string>
     <string name="compress_as">Сжать как…</string>
     <string name="compressing">Сжатие…</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Video súbor</string>
     <string name="other_file">Iný súbor</string>
     <string name="compress">Komprimovať</string>
-    <string name="compress_pro">Komprimovať (Pro)</string>
     <string name="decompress">Dekomprimovať</string>
     <string name="compress_as">Komprimovať ako</string>
     <string name="compressing">Komprimuje sa…</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Video datoteka</string>
     <string name="other_file">Druga datoteka</string>
     <string name="compress">Stisni</string>
-    <string name="compress_pro">Stisni (Pro)</string>
     <string name="decompress">Razširi</string>
     <string name="compress_as">Stisni kot</string>
     <string name="compressing">Stiskanje…</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Видео фајл</string>
     <string name="other_file">Други фајл</string>
     <string name="compress">Стиснитите</string>
-    <string name="compress_pro">Стисни (Про)</string>
     <string name="decompress">Декомпресирајте</string>
     <string name="compress_as">Компресирајте као</string>
     <string name="compressing">Компресира се…</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Videofil</string>
     <string name="other_file">Annan fil</string>
     <string name="compress">Komprimera</string>
-    <string name="compress_pro">Komprimera (Pro)</string>
     <string name="decompress">Packa upp</string>
     <string name="compress_as">Komprimera som</string>
     <string name="compressing">Komprimerar…</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -19,7 +19,6 @@
     <string name="video_file">காணொளி கோப்பு</string>
     <string name="other_file">பிற கோப்பு</string>
     <string name="compress">சுருக்கு</string>
-    <string name="compress_pro">சுருக்கு (Pro)</string>
     <string name="decompress">சுருக்குநீக்கு</string>
     <string name="compress_as">இவ்வாறு சுருக்கு</string>
     <string name="compressing">சுருக்குகிறது…</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Video dosyası</string>
     <string name="other_file">Diğer dosya</string>
     <string name="compress">Sıkıştır</string>
-    <string name="compress_pro">Sıkıştır (Pro)</string>
     <string name="decompress">Çöz</string>
     <string name="compress_as">Sıkıştır:</string>
     <string name="compressing">Sıkıştırılıyor…</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">Відео</string>
     <string name="other_file">Інший тип</string>
     <string name="compress">Стиснути</string>
-    <string name="compress_pro">Стиснути (Pro)</string>
     <string name="decompress">Розпакувати</string>
     <string name="compress_as">Стиснути як</string>
     <string name="compressing">Триває стиснення…</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -18,7 +18,6 @@
     <string name="go_to_favorite">Chuyển đến mục yêu thích</string>
     <string name="go_to_home_folder">Chuyển đến thư mục chính</string>
     <string name="set_as_home_folder">Đặt làm thư mục chính</string>
-    <string name="compress_pro">Nén (Chuyên nghiệp)</string>
     <string name="audio">Âm thanh</string>
     <string name="storage_analysis">Thống kê bộ nhớ</string>
     <string name="documents">Tài liệu</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -20,7 +20,6 @@
     <string name="video_file">视频文件</string>
     <string name="other_file">其他文件</string>
     <string name="compress">压缩</string>
-    <string name="compress_pro">压缩 (Pro)</string>
     <string name="decompress">解压缩</string>
     <string name="compress_as">压缩为</string>
     <string name="compressing">压缩中…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -18,7 +18,6 @@
     <string name="video_file">影片檔案</string>
     <string name="other_file">其他檔案</string>
     <string name="compress">壓縮</string>
-    <string name="compress_pro">壓縮 (Pro)</string>
     <string name="decompress">解壓縮</string>
     <string name="compress_as">壓縮為</string>
     <string name="compressing">壓縮中…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,7 +24,6 @@
 
     <!-- Compression -->
     <string name="compress">Compress</string>
-    <string name="compress_pro">Compress (Pro)</string>
     <string name="decompress">Decompress</string>
     <string name="compress_as">Compress as</string>
     <string name="compressing">Compressing…</string>


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [ ] Bugfix
- [ ] Feature
- [x] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Update strings

I have noticed there is both a "compress" and a "compress_pro" string, the second one was added for the free version of Simple File Manager (https://github.com/SimpleMobileTools/Simple-File-Manager/commit/3edd343a3da6d83ca9ffc787bcb6c1fd0d325aa2) and is no longer useful.
I manually checked if any files used this string, I didn't find any, but just in case it might be better to do an automatic check if you can.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/File-Manager/blob/master/CONTRIBUTING.md).
