### PR TITLE
Fix filename when saving a shared file

### DIFF
--- a/app/src/main/kotlin/org/fossify/filemanager/activities/SaveAsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/SaveAsActivity.kt
@@ -35,10 +35,10 @@ class SaveAsActivity : SimpleActivity() {
                                 }
                             }
 
-                            val source = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)
-                            val mimeType = source!!.toString().getMimeType()
+                            val source = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)!!
+                            val filename = getFilenameFromContentUri(source) ?: source.toString().getFilenameFromPath()
+                            val mimeType = contentResolver.getType(source) ?: intent.getType()?.takeIf { it != "*/*" } ?: filename.getMimeType()
                             val inputStream = contentResolver.openInputStream(source)
-                            val filename = source.toString().getFilenameFromPath()
 
                             val destinationPath = "$destination/$filename"
                             val outputStream = getFileOutputStreamSync(destinationPath, mimeType, null)!!


### PR DESCRIPTION
From the commit message:

> Previously, the code used the last path component of the content URI, but that isn't necessarily the filename -- it can be a numeric ID.
> 
> Switch to the helper function getFilenameFromContentUri(), which uses ContentResolver to read the DISPLAY_NAME column. (If that fails, we fall back to the last component of the content URI as before, because we don't have anything better to use.)
> 
> Also improve the way the MIME type is determined. Previously it was just based on the file extension. Switch to first query the ContentResolver, then try the type of the Intent (which is supposed to be set to the MIME type of the data for ACTION_SEND, but may be set to "*/*" if the type is unknown), and only then fall back to using the file extension.

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Fix filename when saving a shared file
- Improve the way the MIME type is determined

Tested on Android 8.1 and Android 14, sharing both using Fossify File Manager and using the native Files app.

For testing, see the branch 'build/fix-filename-from-sharing-debug' of my fork ([commit](https://github.com/FossifyOrg/File-Manager/commit/16efbd40eccca827b7c740e9c6f03f25b81db180)), which logs all the values of interest (search for lines containing "XXX" in the logcat).

#### Fixes the following issue(s)
- Fixes #37

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/File-Manager/blob/master/CONTRIBUTING.md).
