### PR TITLE
Fixed decompressed directory filename not using ZIP name (#120)

### DIFF
--- a/app/src/main/kotlin/org/fossify/filemanager/activities/DecompressActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/DecompressActivity.kt
@@ -31,6 +31,7 @@ class DecompressActivity : SimpleActivity() {
     private var uri: Uri? = null
     private var password: String? = null
     private var passwordDialog: EnterPasswordDialog? = null
+    private var filename = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         isMaterialActivity = true
@@ -51,7 +52,8 @@ class DecompressActivity : SimpleActivity() {
         password = savedInstanceState?.getString(PASSWORD, null)
 
         val realPath = getRealPathFromURI(uri!!)
-        binding.decompressToolbar.title = realPath?.getFilenameFromPath() ?: Uri.decode(uri.toString().getFilenameFromPath())
+        filename = realPath?.getFilenameFromPath() ?: Uri.decode(uri.toString().getFilenameFromPath())
+        binding.decompressToolbar.title = filename
         setupFilesList()
     }
 
@@ -145,7 +147,7 @@ class DecompressActivity : SimpleActivity() {
             zipInputStream.use {
                 while (true) {
                     val entry = zipInputStream.nextEntry ?: break
-                    val filename = title.toString().substringBeforeLast(".")
+                    val filename = filename.substringBeforeLast(".")
                     val parent = "$destination/$filename"
                     val newPath = "$parent/${entry.fileName.trimEnd('/')}"
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Using ZIP name as a directory name for decompressed files.
- Looking at the code, it seems that it was working some time ago. Probably it has broken during some refactors because `title` was originally keeping the filename.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

https://github.com/user-attachments/assets/955b17fd-dd16-429d-95a3-cb80dd2a297d

- After:

https://github.com/user-attachments/assets/02470ec5-6593-4b7b-bbd8-d9f4a8199fcf

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #120 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/File-Manager/blob/master/CONTRIBUTING.md).
