### PR TITLE
Fixed accidental rendering of swipe refresh indicator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed accidental rendering of pull-to-refresh indicator ([#27])
 - Pull-to-refresh setting is now applied as expected ([#136])
-- Fixed accidental rendering of swipe refresh indicator.
 
 ## [1.0.1] - 2024-03-17
 
@@ -41,4 +41,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.1]: https://github.com/FossifyOrg/File-Manager/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/FossifyOrg/File-Manager/releases/tag/1.0.0
 
+[#27]: https://github.com/FossifyOrg/File-Manager/issues/27
 [#136]: https://github.com/FossifyOrg/File-Manager/issues/136

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced checkboxes with switches
 
+### Fixed
+
+- Fixed accidental rendering of swipe refresh indicator.
+
 ## [1.0.1] - 2024-03-17
 
 ### Changed

--- a/app/src/main/kotlin/org/fossify/filemanager/views/MySwipeRefreshLayout.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/views/MySwipeRefreshLayout.kt
@@ -14,7 +14,7 @@ class MySwipeRefreshLayout @JvmOverloads constructor(
     override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
         // Setting "isEnabled = false" is recommended for users of this ViewGroup
         // who who are not interested in the pull to refresh functionality
-        // Setting this easily avoids executing code unneededsly before the check for "canChildScrollUp".
+        // Setting this easily avoids executing code needlessly before the check for "canChildScrollUp".
         if (!isEnabled) {
             return false
         }

--- a/app/src/main/kotlin/org/fossify/filemanager/views/MySwipeRefreshLayout.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/views/MySwipeRefreshLayout.kt
@@ -5,6 +5,7 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.qtalk.recyclerviewfastscroller.RecyclerViewFastScroller
 
 class MySwipeRefreshLayout @JvmOverloads constructor(
     context: Context,
@@ -29,6 +30,17 @@ class MySwipeRefreshLayout @JvmOverloads constructor(
             return false
         } else {
             super.onStartNestedScroll(child, target, nestedScrollAxes)
+        }
+    }
+
+    override fun canChildScrollUp(): Boolean {
+        val directChild = getChildAt(0)
+        return when (directChild) {
+            is RecyclerViewFastScroller -> {
+                val innerRecyclerView = directChild.getChildAt(0)
+                innerRecyclerView?.canScrollVertically(-1) == true
+            }
+            else -> super.canChildScrollUp()
         }
     }
 }

--- a/app/src/main/kotlin/org/fossify/filemanager/views/MySwipeRefreshLayout.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/views/MySwipeRefreshLayout.kt
@@ -1,0 +1,34 @@
+package org.fossify.filemanager.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+
+class MySwipeRefreshLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : SwipeRefreshLayout(context, attrs) {
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+        // Setting "isEnabled = false" is recommended for users of this ViewGroup
+        // who who are not interested in the pull to refresh functionality
+        // Setting this easily avoids executing code unneededsly before the check for "canChildScrollUp".
+        if (!isEnabled) {
+            return false
+        }
+        return super.onInterceptTouchEvent(ev)
+    }
+
+    override fun onStartNestedScroll(child: View, target: View, nestedScrollAxes: Int): Boolean {
+        // Ignoring nested scrolls from descendants.
+        // Allowing descendants to trigger nested scrolls would defeat the purpose of this class
+        // and result in pull to refresh to happen for all movements on the Y axis
+        // (even as part of scale/quick scale gestures) while also doubling the throbber with the overscroll shadow.
+        return if (isEnabled) {
+            return false
+        } else {
+            super.onStartNestedScroll(child, target, nestedScrollAxes)
+        }
+    }
+}

--- a/app/src/main/res/layout/items_fragment.xml
+++ b/app/src/main/res/layout/items_fragment.xml
@@ -68,7 +68,7 @@
                 android:textStyle="italic"
                 android:visibility="gone" />
 
-            <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            <org.fossify.filemanager.views.MySwipeRefreshLayout
                 android:id="@+id/items_swipe_refresh"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -90,7 +90,7 @@
                         app:layoutManager="org.fossify.commons.views.MyGridLayoutManager" />
 
                 </com.qtalk.recyclerviewfastscroller.RecyclerViewFastScroller>
-            </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+            </org.fossify.filemanager.views.MySwipeRefreshLayout>
         </RelativeLayout>
 
         <org.fossify.commons.views.MyFloatingActionButton

--- a/app/src/main/res/layout/recents_fragment.xml
+++ b/app/src/main/res/layout/recents_fragment.xml
@@ -22,7 +22,7 @@
         android:visibility="gone"
         tools:visibility="visible" />
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+    <org.fossify.filemanager.views.MySwipeRefreshLayout
         android:id="@+id/recents_swipe_refresh"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
@@ -37,5 +37,5 @@
             android:scrollbars="none"
             app:layoutManager="org.fossify.commons.views.MyGridLayoutManager" />
 
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    </org.fossify.filemanager.views.MySwipeRefreshLayout>
 </org.fossify.filemanager.fragments.RecentsFragment>


### PR DESCRIPTION
Hope this [legacy 7-year-old](https://github.com/SimpleMobileTools/Simple-File-Manager/issues/175) issue is now eliminated :)

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Created a fixed version of `SwipeRefreshLayout`, inspired by Firefox's [VerticalSwipeRefreshLayout](https://github.com/mozilla-mobile/firefox-android/blob/fe8a71cd70ad5674abe1824fe11dc78372b736c2/android-components/components/ui/widgets/src/main/java/mozilla/components/ui/widgets/VerticalSwipeRefreshLayout.kt#L28).
Optionally, we can move this file to the [Commons repository](https://github.com/FossifyOrg/Commons/tree/master/commons/src/main/kotlin/org/fossify/commons/views).

#### Fixes the following issue(s)
- Fixes #https://github.com/FossifyOrg/File-Manager/issues/27

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I manually tested my changes on device/emulator (if applicable).


