### PR TITLE
fix: enable pull-to-refresh based on preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Replaced checkboxes with switches
 
+### Fixed
+
+- Pull-to-refresh setting is now applied as expected ([#136])
+
 ## [1.0.1] - 2024-03-17
 
 ### Changed
@@ -35,3 +39,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/FossifyOrg/File-Manager/compare/1.0.1...HEAD
 [1.0.1]: https://github.com/FossifyOrg/File-Manager/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/FossifyOrg/File-Manager/releases/tag/1.0.0
+
+[#136]: https://github.com/FossifyOrg/File-Manager/issues/136

--- a/app/src/main/kotlin/org/fossify/filemanager/adapters/ItemsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/adapters/ItemsAdapter.kt
@@ -220,7 +220,7 @@ class ItemsAdapter(
     }
 
     override fun onActionModeDestroyed() {
-        swipeRefreshLayout?.isEnabled = true
+        swipeRefreshLayout?.isEnabled = config.enablePullToRefresh
     }
 
     override fun getItemViewType(position: Int): Int {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Restore proper pull-to-refresh state when action mode is destroyed. It was being enabled unconditionally.

#### Fixes the following issue(s)
- Fixes #136

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I manually tested my changes on device/emulator (if applicable).