### PR TITLE
Preserve modified date when unzip files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve modified date when unzip files ([#176])
+
 ## [1.1.0] - 2025-05-21
 
 ### Added
@@ -66,3 +70,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#120]: https://github.com/FossifyOrg/File-Manager/issues/120
 [#149]: https://github.com/FossifyOrg/File-Manager/issues/149
 [#150]: https://github.com/FossifyOrg/File-Manager/issues/150
+[#176]: https://github.com/FossifyOrg/File-Manager/issues/176

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/DecompressActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/DecompressActivity.kt
@@ -171,7 +171,9 @@ class DecompressActivity : SimpleActivity() {
                         continue
                     }
 
-                    val isVulnerableForZipPathTraversal = !File(newPath).canonicalPath.startsWith(parent)
+                    val outputFile = File(newPath)
+
+                    val isVulnerableForZipPathTraversal = !outputFile.canonicalPath.startsWith(parent)
                     if (isVulnerableForZipPathTraversal) {
                         continue
                     }
@@ -187,6 +189,7 @@ class DecompressActivity : SimpleActivity() {
                         fos!!.write(buffer, 0, count)
                     }
                     fos!!.close()
+                    outputFile.setLastModified(entry.lastModifiedTimeEpoch)
                 }
 
                 toast(R.string.decompression_successful)

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/DecompressActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/DecompressActivity.kt
@@ -26,6 +26,7 @@ import org.fossify.filemanager.R
 import org.fossify.filemanager.adapters.DecompressItemsAdapter
 import org.fossify.filemanager.databinding.ActivityDecompressBinding
 import org.fossify.filemanager.extensions.config
+import org.fossify.filemanager.extensions.setLastModified
 import org.fossify.filemanager.models.ListItem
 import java.io.BufferedInputStream
 import java.io.File
@@ -189,7 +190,7 @@ class DecompressActivity : SimpleActivity() {
                         fos!!.write(buffer, 0, count)
                     }
                     fos!!.close()
-                    outputFile.setLastModified(entry.lastModifiedTimeEpoch)
+                    outputFile.setLastModified(entry)
                 }
 
                 toast(R.string.decompression_successful)

--- a/app/src/main/kotlin/org/fossify/filemanager/adapters/ItemsAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/adapters/ItemsAdapter.kt
@@ -101,6 +101,7 @@ import org.fossify.filemanager.extensions.config
 import org.fossify.filemanager.extensions.isPathOnRoot
 import org.fossify.filemanager.extensions.isZipFile
 import org.fossify.filemanager.extensions.setAs
+import org.fossify.filemanager.extensions.setLastModified
 import org.fossify.filemanager.extensions.sharePaths
 import org.fossify.filemanager.extensions.toggleItemVisibility
 import org.fossify.filemanager.extensions.tryOpenPathIntent
@@ -693,6 +694,7 @@ class ItemsAdapter(
             val fos = activity.getFileOutputStreamSync(newPath, newPath.getMimeType())
             if (fos != null) {
                 zipInputStream.copyTo(fos)
+                File(newPath).setLastModified(entry)
             }
         }
     }

--- a/app/src/main/kotlin/org/fossify/filemanager/extensions/Zip4j.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/extensions/Zip4j.kt
@@ -1,0 +1,15 @@
+package org.fossify.filemanager.extensions
+
+import net.lingala.zip4j.model.LocalFileHeader
+import java.io.File
+
+fun File.setLastModified(localFileHeader: LocalFileHeader) {
+    setLastModified(localFileHeader.lastModifiedOrCurrentTimeMillis)
+}
+
+private val LocalFileHeader.lastModifiedOrCurrentTimeMillis
+    get() = if (lastModifiedTimeEpoch == 0L) {
+        System.currentTimeMillis()
+    } else {
+        lastModifiedTimeEpoch
+    }


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Preserve the original `lastModifiedTime` of files when unzipping them.  

#### Fixes the following issue(s)
- Fixes https://github.com/FossifyOrg/File-Manager/issues/176

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I manually tested my changes on device/emulator (if applicable).

