### PR TITLE
feat: handle `ACTION_OPEN_DOCUMENT` intent

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -61,6 +61,14 @@
             </intent-filter>
 
             <intent-filter>
+                <action android:name="android.intent.action.OPEN_DOCUMENT" />
+                <data android:mimeType="*/*" />
+
+                <category android:name="android.intent.category.OPENABLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+
+            <intent-filter>
                 <action android:name="android.intent.action.RINGTONE_PICKER" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/MainActivity.kt
@@ -411,7 +411,10 @@ class MainActivity : SimpleActivity() {
     private fun setupTabs() {
         binding.mainTabsHolder.removeAllTabs()
         val action = intent.action
-        val isPickFileIntent = action == RingtoneManager.ACTION_RINGTONE_PICKER || action == Intent.ACTION_GET_CONTENT || action == Intent.ACTION_PICK
+        val isPickFileIntent = action == RingtoneManager.ACTION_RINGTONE_PICKER
+                || action == Intent.ACTION_GET_CONTENT
+                || action == Intent.ACTION_PICK
+                || action == Intent.ACTION_OPEN_DOCUMENT
         val isCreateDocumentIntent = action == Intent.ACTION_CREATE_DOCUMENT
 
         if (isPickFileIntent) {

--- a/app/src/main/kotlin/org/fossify/filemanager/adapters/ViewPagerAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/adapters/ViewPagerAdapter.kt
@@ -22,7 +22,9 @@ class ViewPagerAdapter(val activity: SimpleActivity, val tabsToShow: ArrayList<I
 
         (view as MyViewPagerFragment<*>).apply {
             val isPickRingtoneIntent = activity.intent.action == RingtoneManager.ACTION_RINGTONE_PICKER
-            val isGetContentIntent = activity.intent.action == Intent.ACTION_GET_CONTENT || activity.intent.action == Intent.ACTION_PICK
+            val isGetContentIntent = activity.intent.action == Intent.ACTION_GET_CONTENT
+                    || activity.intent.action == Intent.ACTION_PICK
+                    || activity.intent.action == Intent.ACTION_OPEN_DOCUMENT
             val isCreateDocumentIntent = activity.intent.action == Intent.ACTION_CREATE_DOCUMENT
             val allowPickingMultipleIntent = activity.intent.getBooleanExtra(Intent.EXTRA_ALLOW_MULTIPLE, false)
             val getContentMimeType = if (isGetContentIntent) {


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
- Handled `ACTION_OPEN_DOCUMENT` same as `ACTION_GET_CONTENT`

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). -->
- Fixes #213 (well, kind of)

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
