### PR TITLE
fix: trust the system to check whether a file is a directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed folders showing up incorrectly as files in some cases ([#80])
 
 ## [1.2.2] - 2025-09-01
 ### Changed
@@ -58,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#27]: https://github.com/FossifyOrg/File-Manager/issues/27
 [#37]: https://github.com/FossifyOrg/File-Manager/issues/37
+[#80]: https://github.com/FossifyOrg/File-Manager/issues/80
 [#105]: https://github.com/FossifyOrg/File-Manager/issues/105
 [#106]: https://github.com/FossifyOrg/File-Manager/issues/106
 [#120]: https://github.com/FossifyOrg/File-Manager/issues/120

--- a/app/src/main/kotlin/org/fossify/filemanager/fragments/ItemsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/fragments/ItemsFragment.kt
@@ -257,7 +257,7 @@ class ItemsFragment(context: Context, attributeSet: AttributeSet) : MyViewPagerF
         }
 
         var lastModified = lastModifieds.remove(curPath)
-        val isDirectory = if (lastModified != null) false else file.isDirectory
+        val isDirectory = file.isDirectory
         val children = if (isDirectory && getProperChildCount) file.getDirectChildrenCount(context, showHidden) else 0
         val size = if (isDirectory) {
             if (isSortingBySize) {


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
The directory check relied on MediaStore presence to determine if a given file was a directory. Now it doesn't.

The condition was originally introduced in 12b96e159d25551d6099546bca72d51d184d7bcf

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/File-Manager/issues/80 (maybe)

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
