### PR TITLE
Fix file access permission if opened for the first time via "share" #85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed folders showing up incorrectly as files in copy/move dialog ([#267])
 - Fixed error when saving files with unsupported characters ([#250])
+- Fixed File manager does not ask for file access permission if opened for the first time via "share" dialog ([#85])
 
 ## [1.2.3] - 2025-09-15
 ### Fixed
@@ -76,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#251]: https://github.com/FossifyOrg/File-Manager/issues/251
 [#267]: https://github.com/FossifyOrg/File-Manager/issues/267
 [#250]: https://github.com/FossifyOrg/File-Manager/issues/250
+[#85]: https://github.com/FossifyOrg/File-Manager/issues/85
 
 [Unreleased]: https://github.com/FossifyOrg/File-Manager/compare/1.2.3...HEAD
 [1.2.3]: https://github.com/FossifyOrg/File-Manager/compare/1.2.2...1.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed folders showing up incorrectly as files in copy/move dialog ([#267])
+- Fixed filename error in Save As-Dialog ([#50])
 
 ## [1.2.3] - 2025-09-15
 ### Fixed
@@ -74,6 +75,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#176]: https://github.com/FossifyOrg/File-Manager/issues/176
 [#251]: https://github.com/FossifyOrg/File-Manager/issues/251
 [#267]: https://github.com/FossifyOrg/File-Manager/issues/267
+[#250]: https://github.com/FossifyOrg/File-Manager/issues/250
+
 
 [Unreleased]: https://github.com/FossifyOrg/File-Manager/compare/1.2.3...HEAD
 [1.2.3]: https://github.com/FossifyOrg/File-Manager/compare/1.2.2...1.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed folders showing up incorrectly as files in copy/move dialog ([#267])
 
 ## [1.2.3] - 2025-09-15
 ### Fixed
@@ -71,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#150]: https://github.com/FossifyOrg/File-Manager/issues/150
 [#176]: https://github.com/FossifyOrg/File-Manager/issues/176
 [#251]: https://github.com/FossifyOrg/File-Manager/issues/251
+[#267]: https://github.com/FossifyOrg/File-Manager/issues/267
 
 [Unreleased]: https://github.com/FossifyOrg/File-Manager/compare/1.2.3...HEAD
 [1.2.3]: https://github.com/FossifyOrg/File-Manager/compare/1.2.2...1.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#267]: https://github.com/FossifyOrg/File-Manager/issues/267
 [#250]: https://github.com/FossifyOrg/File-Manager/issues/250
 
-
 [Unreleased]: https://github.com/FossifyOrg/File-Manager/compare/1.2.3...HEAD
 [1.2.3]: https://github.com/FossifyOrg/File-Manager/compare/1.2.2...1.2.3
 [1.2.2]: https://github.com/FossifyOrg/File-Manager/compare/1.2.0...1.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed folders showing up incorrectly as files in copy/move dialog ([#267])
-- Fixed filename error in Save As-Dialog ([#50])
+- Fixed error when saving files with unsupported characters ([#250])
 
 ## [1.2.3] - 2025-09-15
 ### Fixed

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/SaveAsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/SaveAsActivity.kt
@@ -68,7 +68,7 @@ class SaveAsActivity : SimpleActivity() {
         setupToolbar(binding.activitySaveAsToolbar, NavigationIcon.Arrow)
     }
 
-    fun sanitizeFilename(filename: String): String {
+    private fun sanitizeFilename(filename: String): String {
         return filename.replace("[/\\\\<>:\"|?*\u0000-\u001F]".toRegex(), "_")
             .takeIf { it.isNotBlank() } ?: "unnamed_file"
     }

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/SaveAsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/SaveAsActivity.kt
@@ -36,8 +36,9 @@ class SaveAsActivity : SimpleActivity() {
                             }
 
                             val source = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)!!
-                            val filename = getFilenameFromContentUri(source)
+                            val originalFilename = getFilenameFromContentUri(source)
                                 ?: source.toString().getFilenameFromPath()
+                            val filename = sanitizeFilename(originalFilename)
                             val mimeType = contentResolver.getType(source)
                                 ?: intent.type?.takeIf { it != "*/*" }
                                 ?: filename.getMimeType()
@@ -65,5 +66,10 @@ class SaveAsActivity : SimpleActivity() {
     override fun onResume() {
         super.onResume()
         setupToolbar(binding.activitySaveAsToolbar, NavigationIcon.Arrow)
+    }
+
+    fun sanitizeFilename(filename: String): String {
+        return filename.replace("[/\\\\<>:\"|?*\u0000-\u001F]".toRegex(), "_")
+            .takeIf { it.isNotBlank() } ?: "unnamed_file"
     }
 }

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/SaveAsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/SaveAsActivity.kt
@@ -1,12 +1,16 @@
 package org.fossify.filemanager.activities
 
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.Environment
+import androidx.core.net.toUri
 import org.fossify.commons.dialogs.FilePickerDialog
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.NavigationIcon
 import org.fossify.commons.helpers.ensureBackgroundThread
+import org.fossify.commons.helpers.isRPlus
 import org.fossify.filemanager.R
 import org.fossify.filemanager.databinding.ActivitySaveAsBinding
 import org.fossify.filemanager.extensions.config
@@ -15,9 +19,18 @@ import java.io.File
 class SaveAsActivity : SimpleActivity() {
     private val binding by viewBinding(ActivitySaveAsBinding::inflate)
 
+    companion object {
+        private const val MANAGE_STORAGE_RC = 201
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(binding.root)
+        if (isRPlus() && !Environment.isExternalStorageManager()) {
+            val intent = Intent(android.provider.Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION)
+            intent.data = "package:$packageName".toUri()
+            startActivityForResult(intent, MANAGE_STORAGE_RC)
+            return
+        }
 
         if (intent.action == Intent.ACTION_SEND && intent.extras?.containsKey(Intent.EXTRA_STREAM) == true) {
             FilePickerDialog(this, pickFile = false, showHidden = config.shouldShowHidden(), showFAB = true, showFavoritesButton = true) {
@@ -71,5 +84,19 @@ class SaveAsActivity : SimpleActivity() {
     private fun sanitizeFilename(filename: String): String {
         return filename.replace("[/\\\\<>:\"|?*\u0000-\u001F]".toRegex(), "_")
             .takeIf { it.isNotBlank() } ?: "unnamed_file"
+    }
+
+    @SuppressLint("NewApi")
+    override fun onActivityResult(requestCode: Int, resultCode: Int, dataIntent: Intent?) {
+        super.onActivityResult(requestCode, resultCode, dataIntent)
+
+        if (requestCode == MANAGE_STORAGE_RC && isRPlus()) {
+            if (Environment.isExternalStorageManager()) {
+                recreate()
+            } else {
+                toast(R.string.no_storage_permissions)
+                finish()
+            }
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ detektCompose = "0.4.27"
 androidx-swiperefreshlayout = "1.1.0"
 androidx-documentfile = "1.1.0"
 #Fossify
-commons = "5.0.2"
+commons = "5.1.1"
 #Other
 autofittextview = "0.2.1"
 gestureviews = "2.8.3"


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Fixed file access permission if opened for the first time via "share"

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->
reuses the file permission view from mainactivity

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #85 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
