### PR TITLE
add save as in menu in TextEditor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed missing permission prompt on initial "Save as" launch ([#85])
 - Fixed printing text files containing a "#" ([#104])
 
+### Changed
+- "Save as" moved to menu in Text Editor ([#224])
+
 ## [1.2.3] - 2025-09-15
 ### Fixed
 - Fixed folders showing up incorrectly as files in some cases ([#80])
@@ -80,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#250]: https://github.com/FossifyOrg/File-Manager/issues/250
 [#85]: https://github.com/FossifyOrg/File-Manager/issues/85
 [#104]: https://github.com/FossifyOrg/File-Manager/issues/104
+[#224]: https://github.com/FossifyOrg/File-Manager/issues/224
 
 [Unreleased]: https://github.com/FossifyOrg/File-Manager/compare/1.2.3...HEAD
 [1.2.3]: https://github.com/FossifyOrg/File-Manager/compare/1.2.2...1.2.3

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/ReadTextActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/ReadTextActivity.kt
@@ -128,7 +128,7 @@ class ReadTextActivity : SimpleActivity() {
                 lastSavePromptTS = System.currentTimeMillis()
                 ConfirmationAdvancedDialog(this, "", R.string.save_before_closing, R.string.save, R.string.discard) {
                     if (it) {
-                        saveText(true)
+                        saveAsText(true)
                     } else {
                         super.onBackPressed()
                     }
@@ -144,6 +144,7 @@ class ReadTextActivity : SimpleActivity() {
             when (menuItem.itemId) {
                 R.id.menu_search -> openSearch()
                 R.id.menu_save -> saveText()
+                R.id.menu_save_as -> saveAsText()
                 R.id.menu_open_with -> openPath(intent.dataString!!, true)
                 R.id.menu_print -> printText()
                 else -> return@setOnMenuItemClickListener false
@@ -165,10 +166,14 @@ class ReadTextActivity : SimpleActivity() {
         }, 250)
     }
 
-    private fun saveText(shouldExitAfterSaving: Boolean = false) {
+    private fun getFilePath(){
         if (filePath.isEmpty()) {
             filePath = getRealPathFromURI(intent.data!!) ?: ""
         }
+    }
+
+    private fun saveAsText(shouldExitAfterSaving: Boolean = false) {
+        getFilePath()
 
         if (filePath.isEmpty()) {
             SaveAsDialog(this, filePath, true) { _, filename ->
@@ -182,6 +187,7 @@ class ReadTextActivity : SimpleActivity() {
                     } else {
                         SELECT_SAVE_FILE_INTENT
                     }
+                    @Suppress("DEPRECATION")
                     startActivityForResult(this, requestCode)
                 }
             }
@@ -197,6 +203,20 @@ class ReadTextActivity : SimpleActivity() {
                     toast(R.string.no_storage_permissions)
                 }
             }
+        }
+    }
+
+    private fun saveText(shouldExitAfterSaving: Boolean = false) {
+        getFilePath()
+
+        if (hasStoragePermission()) {
+            val file = File(filePath)
+            getFileOutputStream(file.toFileDirItem(this), true) {
+                val shouldOverwriteOriginalText = true
+                saveTextContent(it, shouldExitAfterSaving, shouldOverwriteOriginalText)
+            }
+        } else {
+            toast(R.string.no_storage_permissions)
         }
     }
 

--- a/app/src/main/res/menu/menu_editor.xml
+++ b/app/src/main/res/menu/menu_editor.xml
@@ -11,8 +11,13 @@
     <item
         android:id="@+id/menu_save"
         android:icon="@drawable/ic_save_vector"
-        android:title="@string/save_as"
+        android:title="@string/save"
         app:showAsAction="always" />
+    <item
+        android:id="@+id/menu_save_as"
+        android:icon="@drawable/ic_print_vector"
+        android:title="@string/save_as"
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/menu_print"
         android:icon="@drawable/ic_print_vector"

--- a/app/src/main/res/menu/menu_editor.xml
+++ b/app/src/main/res/menu/menu_editor.xml
@@ -15,7 +15,7 @@
         app:showAsAction="always" />
     <item
         android:id="@+id/menu_save_as"
-        android:icon="@drawable/ic_print_vector"
+        android:icon="@drawable/ic_save_vector"
         android:title="@string/save_as"
         app:showAsAction="ifRoom" />
     <item


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- add save as in menu
- rename saveText to saveAsText()
- add new save() without confirmation

Unsure about:
- added deprecation-Tag because otherwise I couldn't build locally
```
@Suppress("DEPRECATION")
startActivityForResult(this, requestCode)
```
- using same icon for **Save** and **Save as**
Suggested idea, change order to:
1. **Print** displayed as Action ifRoom
2. **Save As** displayed as Action never
3. **Open with** displayed as Action never

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - new **Save**-Button saves without confirmation
 - **Save As**-Button uses old Save Logic

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->
- new "Save as"-menuItem in TextEditor
<img width="348" height="216" alt="image" src="https://github.com/user-attachments/assets/d5aa307a-61a6-42da-b4be-983ec4c77621" />


#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #224 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
