### PR TITLE
fix: filter out files from hidden folders in storage tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed files from hidden folders showing up in storage tab browser ([#217])
 
 ## [1.3.0] - 2025-09-30
 ### Added

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/MimeTypesActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/MimeTypesActivity.kt
@@ -25,6 +25,7 @@ import org.fossify.filemanager.databinding.ActivityMimetypesBinding
 import org.fossify.filemanager.dialogs.ChangeSortingDialog
 import org.fossify.filemanager.dialogs.ChangeViewTypeDialog
 import org.fossify.filemanager.extensions.config
+import org.fossify.filemanager.extensions.isPathInHiddenFolder
 import org.fossify.filemanager.extensions.tryOpenPathIntent
 import org.fossify.filemanager.helpers.*
 import org.fossify.filemanager.interfaces.ItemOperationsListener
@@ -288,7 +289,10 @@ class MimeTypesActivity : SimpleActivity(), ItemOperationsListener {
                 try {
                     val fullMimetype = cursor.getStringValue(MediaStore.Files.FileColumns.MIME_TYPE)?.lowercase(Locale.getDefault()) ?: return@queryCursor
                     val name = cursor.getStringValue(MediaStore.Files.FileColumns.DISPLAY_NAME)
-                    if (!showHidden && name.startsWith(".")) {
+                    val path = cursor.getStringValue(MediaStore.Files.FileColumns.DATA)
+                    
+                    val isHiddenFile = name.startsWith(".")
+                    if (!showHidden && (isHiddenFile || path.isPathInHiddenFolder())) {
                         return@queryCursor
                     }
 
@@ -297,7 +301,6 @@ class MimeTypesActivity : SimpleActivity(), ItemOperationsListener {
                         return@queryCursor
                     }
 
-                    val path = cursor.getStringValue(MediaStore.Files.FileColumns.DATA)
                     val lastModified = cursor.getLongValue(MediaStore.Files.FileColumns.DATE_MODIFIED) * 1000
 
                     val mimetype = fullMimetype.substringBefore("/")

--- a/app/src/main/kotlin/org/fossify/filemanager/extensions/String.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/extensions/String.kt
@@ -1,3 +1,15 @@
 package org.fossify.filemanager.extensions
 
 fun String.isZipFile() = endsWith(".zip", true)
+
+fun String.isPathInHiddenFolder(): Boolean {
+    val parts = split("/")
+    for (i in 1 until parts.size - 1) {
+        val part = parts[i]
+        val isHidden = part.startsWith(".") && part != "." && part != ".." && part.isNotEmpty()
+        if (isHidden) {
+            return true
+        }
+    }
+    return false
+}

--- a/app/src/main/kotlin/org/fossify/filemanager/fragments/RecentsFragment.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/fragments/RecentsFragment.kt
@@ -25,6 +25,7 @@ import org.fossify.filemanager.activities.SimpleActivity
 import org.fossify.filemanager.adapters.ItemsAdapter
 import org.fossify.filemanager.databinding.RecentsFragmentBinding
 import org.fossify.filemanager.extensions.config
+import org.fossify.filemanager.extensions.isPathInHiddenFolder
 import org.fossify.filemanager.helpers.MAX_COLUMN_COUNT
 import org.fossify.filemanager.interfaces.ItemOperationsListener
 import org.fossify.filemanager.models.ListItem
@@ -180,7 +181,7 @@ class RecentsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
                         val size = cursor.getLongValue(FileColumns.SIZE)
                         val modified = cursor.getLongValue(FileColumns.DATE_MODIFIED) * 1000
                         val isHiddenFile = name.startsWith(".")
-                        val shouldShow = showHidden || (!isHiddenFile && !isPathInHiddenFolder(path))
+                        val shouldShow = showHidden || (!isHiddenFile && !path.isPathInHiddenFolder())
                         if (shouldShow && activity?.getDoesFilePathExist(path) == true) {
                             if (wantedMimeTypes.any { isProperMimeType(it, path, false) }) {
                                 val fileDirItem = ListItem(path, name, false, 0, size, modified, false, false)
@@ -197,18 +198,6 @@ class RecentsFragment(context: Context, attributeSet: AttributeSet) : MyViewPage
         activity?.runOnUiThread {
             callback(listItems)
         }
-    }
-
-    private fun isPathInHiddenFolder(path: String): Boolean {
-        val parts = path.split("/")
-        for (i in 1 until parts.size - 1) {
-            val part = parts[i]
-            val isHidden = part.startsWith(".") && part != "." && part != ".." && part.isNotEmpty()
-            if (isHidden) {
-                return true
-            }
-        }
-        return false
     }
 
     private fun getRecyclerAdapter() = binding.recentsList.adapter as? ItemsAdapter


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Applied the same fix as #217 for the storage tab.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Hiding/showing hidden media/archives/documents in the storage tab browser

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- https://github.com/FossifyOrg/File-Manager/issues/217 (related report)
- https://github.com/FossifyOrg/File-Manager/issues/33 (related report)

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
