### PR TITLE
docs: move incorrectly placed changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed an issue where existing files were overwritten when saving new files ([#131])
 
 ## [1.4.0] - 2025-10-29
 ### Changed


### PR DESCRIPTION
Incorrect placement in https://github.com/FossifyOrg/File-Manager/pull/332. GitHub PR preview is not working properly