### PR TITLE
Fix toolbar back arrow discarding unsaved changes in File Editor

### DIFF
--- a/app/src/main/kotlin/org/fossify/filemanager/activities/ReadTextActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/ReadTextActivity.kt
@@ -96,6 +96,9 @@ class ReadTextActivity : SimpleActivity() {
     override fun onResume() {
         super.onResume()
         setupTopAppBar(binding.readTextAppbar, NavigationIcon.Arrow)
+        binding.readTextToolbar.setNavigationOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
## Summary
- **Fixes #362** — The toolbar back arrow in the File Editor (`ReadTextActivity`) was calling `finish()` directly via `setupTopAppBar`, bypassing the unsaved changes dialog shown by `onBackPressedCompat()`
- Override the navigation click listener after `setupTopAppBar` to route through `onBackPressedDispatcher.onBackPressed()`, ensuring the save/discard prompt appears for both the system back gesture and the toolbar arrow

## Changes
- `ReadTextActivity.kt` — Added `setNavigationOnClickListener` after `setupTopAppBar` in `onResume()` to delegate to `onBackPressedDispatcher`

## How it works
`onBackPressedCompat()` already handles:
1. Closing search if active
2. Showing "Save / Discard" dialog if there are unsaved changes
3. Falling through to default back behavior otherwise

Previously, only the **system back button/gesture** triggered this flow. The **toolbar arrow** called `finish()` directly (set by `setupTopAppBar` in fossify-commons), so edits were silently discarded.

Now both paths go through `onBackPressedDispatcher.onBackPressed()` → `onBackPressedCompat()`.

## Test plan
- [x] Open a text file in the File Editor
- [x] Make changes to the text
- [x] Tap the **toolbar back arrow** → Save/Discard dialog should appear
- [x] System back gesture → Save/Discard dialog should appear (existing behavior, unchanged)
- [x] No changes made → both back methods exit immediately (no dialog)
- [x] Build compiles successfully (`compileFossDebugKotlin`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)