### PR TITLE
fix: guard the text editor against opening very large files (OOM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed the modification of the original timestamp when decompressing folders ([#190])
+- Fixed a crash when opening very large text files in the built-in editor by adding a 1 MB size limit ([#123])
 
 ## [1.6.1] - 2026-02-14
 ### Changed
@@ -125,6 +126,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#105]: https://github.com/FossifyOrg/File-Manager/issues/105
 [#106]: https://github.com/FossifyOrg/File-Manager/issues/106
 [#120]: https://github.com/FossifyOrg/File-Manager/issues/120
+[#123]: https://github.com/FossifyOrg/File-Manager/issues/123
 [#131]: https://github.com/FossifyOrg/File-Manager/issues/131
 [#136]: https://github.com/FossifyOrg/File-Manager/issues/136
 [#149]: https://github.com/FossifyOrg/File-Manager/issues/149

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/ReadTextActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/ReadTextActivity.kt
@@ -34,6 +34,7 @@ class ReadTextActivity : SimpleActivity() {
         private const val SELECT_SAVE_FILE_INTENT = 1
         private const val SELECT_SAVE_FILE_AND_EXIT_INTENT = 2
         private const val KEY_UNSAVED_TEXT = "KEY_UNSAVED_TEXT"
+        private const val FILE_SIZE_LIMIT = 1000 * 1000 // 1 MB, same limit as Fossify Notes
     }
 
     private val binding by viewBinding(ActivityReadTextBinding::inflate)
@@ -285,6 +286,18 @@ class ReadTextActivity : SimpleActivity() {
     }
 
     private fun checkIntent(uri: Uri, savedInstanceState: Bundle?) {
+        val fileSize = if (uri.scheme == "file") {
+            File(uri.path!!).length()
+        } else {
+            getSizeFromContentUri(uri)
+        }
+
+        if (fileSize > FILE_SIZE_LIMIT) {
+            toast(R.string.file_too_large)
+            finish()
+            return
+        }
+
         originalText = if (uri.scheme == "file") {
             filePath = uri.path!!
             val file = File(filePath)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- File Editor -->
     <string name="file_editor">File Editor</string>
+    <string name="file_too_large">File too large, the limit is 1MB</string>
 
     <!-- Storage analysis -->
     <string name="storage_analysis">Storage analysis</string>


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
Opening a large text file from the file list crashed the app. `ReadTextActivity.checkIntent()` reads the entire file into memory before setting it on the `EditText`. When a file is opened from the File-Manager list, commons `openPathIntent` adds the `REAL_FILE_PATH` extra, so the activity builds a `file://` Uri and takes the `file.readText()` branch. That branch only catches `Exception`, but reading a 100+ MB file throws `java.lang.OutOfMemoryError` (an `Error`, not an `Exception`), so it goes uncaught and the app crashes. (The `content://` branch already catches `OutOfMemoryError`, so the behaviour was inconsistent.) Even if the read succeeded, `setText()` of such large text on the UI thread would OOM/ANR.

This adds a 1 MB size guard at the start of `checkIntent()` — the same limit used by Fossify Notes — checked before any read. If the file exceeds the limit, a "File too large, the limit is 1MB" toast is shown and the activity finishes instead of loading the file. The check covers both `file://` (via `File.length()`) and `content://` (via `getSizeFromContentUri`) sources. As requested by @Aga-C on the issue, the message string mirrors Fossify Notes.

Changes:
- `ReadTextActivity.kt`: add `FILE_SIZE_LIMIT = 1000 * 1000` constant and a size check in `checkIntent()`.
- `strings.xml`: add `file_too_large` string.
- `CHANGELOG.md`: note the fix under Unreleased / Fixed and add the `[#123]` link reference.

No new imports were needed: `File` is already imported and `getSizeFromContentUri`, `toast` and `finish` are available via the existing `org.fossify.commons.extensions.*` import.

#### Tests performed
Built `fossDebug`, installed on an Android 15 (API 35) emulator.
- Opened a **5 MB** text file via the built-in editor (`ReadTextActivity`): the activity now finishes immediately with a "File too large" toast and **no OutOfMemory/crash** (logcat clean). Before the fix this OOM-crashed.
- A small text file still opens normally and shows its content in the editor.
- `detekt`, `lint`, unit tests and build all pass locally (CI-equivalent).

#### Closes the following issue(s)
- Closes #123

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
