### PR TITLE
fix: guard against ActivityNotFoundException when requesting all-files access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed the modification of the original timestamp when decompressing folders ([#190])
+- Fixed a crash when requesting storage access on devices without an all-files-access settings screen (e.g. Android TV) ([#295])
 
 ## [1.6.1] - 2026-02-14
 ### Changed
@@ -135,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#250]: https://github.com/FossifyOrg/File-Manager/issues/250
 [#251]: https://github.com/FossifyOrg/File-Manager/issues/251
 [#267]: https://github.com/FossifyOrg/File-Manager/issues/267
+[#295]: https://github.com/FossifyOrg/File-Manager/issues/295
 
 [Unreleased]: https://github.com/FossifyOrg/File-Manager/compare/1.6.1...HEAD
 [1.6.1]: https://github.com/FossifyOrg/File-Manager/compare/1.6.0...1.6.1

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/SimpleActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/SimpleActivity.kt
@@ -81,9 +81,13 @@ open class SimpleActivity : BaseSimpleActivity() {
                             startActivityForResult(intent, MANAGE_STORAGE_RC)
                         } catch (e: android.content.ActivityNotFoundException) {
                             showErrorToast(e)
-                            val intent = Intent()
-                            intent.action = Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION
-                            startActivityForResult(intent, MANAGE_STORAGE_RC)
+                            try {
+                                val intent = Intent()
+                                intent.action = Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION
+                                startActivityForResult(intent, MANAGE_STORAGE_RC)
+                            } catch (_: Exception) {
+                                finish()
+                            }
                         } catch (e: SecurityException) {
                             showErrorToast(e)
                             finish()


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
On Android 11+ (R+), `SimpleActivity.handleStoragePermission()` first launches `Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION` inside a `try`. If that screen is unavailable it catches `ActivityNotFoundException` and falls back to the generic `Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION`. That fallback `startActivityForResult` call was itself **unguarded**, so on devices whose Settings lacks *both* all-files-access screens (e.g. Android TV) the fallback also throws `ActivityNotFoundException`, which propagated uncaught and crashed the app.

This matches the issue's logcat exactly: two `ActivityTaskManager` START lines (`MANAGE_APP_ALL_FILES_ACCESS_PERMISSION` then `MANAGE_ALL_FILES_ACCESS_PERMISSION`) followed by `FATAL EXCEPTION` `No Activity found to handle Intent { act=android.settings.MANAGE_ALL_FILES_ACCESS_PERMISSION }` originating from `handleStoragePermission$lambda$0`.

The fix wraps the fallback intent launch in its own `try/catch`; on failure it calls `finish()` gracefully, mirroring the existing `SecurityException` branch directly below. No new imports are required. CHANGELOG updated under the Unreleased `### Fixed` section.

#### Tests performed
- `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).
- Source-verified: `startActivityForResult(ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION)` is now wrapped in `try/catch`, falling back to `finish()` if no matching Settings activity exists (the reported `ActivityNotFoundException`). This is a defensive guard that can only prevent the crash.
- Note: the stock emulator *has* that Settings screen, so the original crash can't be reproduced here; verified via CI + code review.

#### Closes the following issue(s)
- Closes #295

#### Checklist
- [x] I read the contribution guidelines.
- [ ] I manually tested my changes on device/emulator (verified via CI + source review; see Tests performed).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
