### PR TITLE
fix: refresh the Files tab after extracting an archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fixed the modification of the original timestamp when decompressing folders ([#190])
+- Fixed the Files tab not refreshing after decompressing a ZIP archive from the file preview screen ([#194])
 
 ## [1.6.1] - 2026-02-14
 ### Changed
@@ -130,6 +131,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#149]: https://github.com/FossifyOrg/File-Manager/issues/149
 [#150]: https://github.com/FossifyOrg/File-Manager/issues/150
 [#176]: https://github.com/FossifyOrg/File-Manager/issues/176
+[#194]: https://github.com/FossifyOrg/File-Manager/issues/194
 [#217]: https://github.com/FossifyOrg/File-Manager/issues/217
 [#224]: https://github.com/FossifyOrg/File-Manager/issues/224
 [#250]: https://github.com/FossifyOrg/File-Manager/issues/250

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/DecompressActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/DecompressActivity.kt
@@ -34,6 +34,9 @@ import java.io.File
 class DecompressActivity : SimpleActivity() {
     companion object {
         private const val PASSWORD = "password"
+
+        // set on successful extraction so MainActivity can open the extracted folder on resume
+        var extractedFolderPath: String? = null
     }
 
     private val binding by viewBinding(ActivityDecompressBinding::inflate)
@@ -202,8 +205,12 @@ class DecompressActivity : SimpleActivity() {
                 for ((outputFile, entry) in foldersTimestamp.asReversed()) {
                     outputFile.setLastModified(entry)
                 }
-                toast(R.string.decompression_successful)
-                finish()
+                val extractedFolder = "$destination/${filename.substringBeforeLast(".")}"
+                runOnUiThread {
+                    toast(R.string.decompression_successful)
+                    extractedFolderPath = extractedFolder
+                    finish()
+                }
             }
         } catch (e: Exception) {
             showErrorToast(e)

--- a/app/src/main/kotlin/org/fossify/filemanager/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/filemanager/activities/MainActivity.kt
@@ -153,6 +153,11 @@ class MainActivity : SimpleActivity() {
         if (binding.mainViewPager.adapter == null) {
             initFragments()
         }
+
+        DecompressActivity.extractedFolderPath?.let { path ->
+            DecompressActivity.extractedFolderPath = null
+            openPath(path, true)
+        }
     }
 
     override fun onPause() {


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
When a ZIP is opened from the Files tab, its contents are shown in `DecompressActivity`, which is launched via an implicit `ACTION_VIEW` intent (registered for `application/zip` in the manifest) rather than `startActivityForResult`. On successful extraction the activity only called `toast(R.string.decompression_successful)` and `finish()`, so `MainActivity` had no way to learn that new content had been written. `MainActivity.onResume()` never re-reads the current directory and `ItemsFragment.onResume()` only updates colors/fastscroller/breadcrumb, so the extracted folder only appeared after a manual swipe-to-refresh.

`DecompressActivity` now records the extracted folder path in a plain-`String` companion field (`extractedFolderPath`) on successful extraction. Unlike closed PR #273's `companion object var onDecompressFinished: ((String) -> Unit)?`, this holds no `Activity`/lambda reference, so it cannot leak `MainActivity`. `MainActivity.onResume()` consumes and clears the field, calling `openPath(path, forceRefresh = true)` to navigate the Files tab into the freshly extracted folder. Both the write and the read happen on the main thread (`runOnUiThread` / `onResume`), so no `@Volatile`/synchronization is required.

Note: the other decompress entry point (long-press a ZIP -> CAB decompress icon -> `ItemsAdapter.decompressSelection`) already refreshes via `listener?.refreshFragment()` and is unaffected by this change.

#### Tests performed
- `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).
- Source-verified: after a successful decompression, `DecompressActivity` records the extracted folder path and `MainActivity` opens/refreshes that path on return, so the Files tab updates without a manual pull-to-refresh.
- Note: exercised via CI + code review; the extraction UI flow was not scripted end-to-end on the emulator.

#### Closes the following issue(s)
- Closes #194

#### Checklist
- [x] I read the contribution guidelines.
- [ ] I manually tested my changes on device/emulator (verified via CI + source review; see Tests performed).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
