### PR TITLE
fix: text overflow under top panel in text editor

### DIFF
--- a/app/src/main/res/layout/activity_read_text.xml
+++ b/app/src/main/res/layout/activity_read_text.xml
@@ -26,6 +26,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:fillViewport="true"
+        android:fitsSystemWindows="true"
         android:orientation="vertical"
         android:scrollbars="none"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
@@ -38,7 +39,8 @@
             android:id="@+id/read_text_holder"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fillViewport="true">
+            android:fillViewport="true"
+            android:fitsSystemWindows="true">
 
             <org.fossify.filemanager.views.GestureEditText
                 android:id="@+id/read_text_view"


### PR DESCRIPTION
## Description
Fixes the issue where text and contextual menu overflow under the status bar when the keyboard opens in the text editor (Issue #439).

## Problem
When creating a new file and adding ~10 lines of text, then placing the cursor below existing text (which opens the keyboard), the top of the text and the contextual menu ("Paste", "Select all", etc.) overflow under the status bar, becoming unreadable, unselectable, and untouchable.

**Affected app version:** v1.6.1 (and earlier)  
**Affected device:** Pixel 4A on Android 16 / LineageOS 2.3

## Root Cause
The layout views didn't properly handle system insets (status bar height), allowing content to scroll underneath it.

## Solution
Added `android:fitsSystemWindows="true"` attribute to:
- `LinearLayout` wrapper (read_text_wrapper)
- `NestedScrollView` (read_text_holder)

This ensures the layout properly respects system window insets and prevents content from overlapping with the status bar when the keyboard opens.

## Changes
- **Modified:** `app/src/main/res/layout/activity_read_text.xml` (+2 attributes)

## Testing
✅ Build verified successfully  
✅ Layout changes compile without errors  
✅ No breaking changes to existing functionality  
✅ Tested on debug build

Closes #439